### PR TITLE
Updated BME680 YAML file to enable full VOC functionality 

### DIFF
--- a/esphome/bme680.yaml
+++ b/esphome/bme680.yaml
@@ -1,20 +1,82 @@
-sensor:
-  - platform: bme680
+bme680_bsec:
+    # i2c address
+    # -----------
+    # Common values are:
+    # - 0x76
+    # - 0x77
+    # Default: 0x76
     address: 0x77
-    update_interval: 60s
+
+    # Temperature offset
+    # ------------------
+    # Useful if device is in enclosure and reads too high
+    # Default: 0
+    temperature_offset: 3
+
+    # IAQ calculation mode
+    # --------------------
+    # Available options:
+    # - static (for fixed position devices)
+    # - mobile (for on person or other moveable devices)
+    # Default: static
+    iaq_mode: static
+
+    # Sample rate
+    # -----------
+    # Available options:
+    # - lp (low power - samples every 3 seconds)
+    # - ulp (ultra low power - samples every 5 minutes)
+    # Default: lp
+    sample_rate: lp
+
+    # Interval at which to save BSEC state
+    # ------------------------------------
+    # Default: 6h
+    state_save_interval: 6h
+ 
+ 
+sensor:
+  - platform: bme680_bsec
     temperature:
-      id: temp
-      name: "${upper_devicename} Temperature"
-      oversampling: 16x
+     id: temp
+     name: "${upper_devicename} Temperature"
+     filters:
+       - median
     pressure:
-      id: pressure
-      name: "${upper_devicename} Pressure"
+     id: pressure
+     name: "${upper_devicename} Pressure"
+     filters:
+      - median 
     humidity:
-      id: humidity
-      name: "${upper_devicename} Humidity"
+     id: humidity
+     name: "${upper_devicename} Humidity"
+     filters:
+      - median
+    iaq:
+     name: "${upper_devicename} iaq"
+     id: iaq
+     filters:
+      - median
+    breath_voc_equivalent:
+     id: voc_equ
+     name: "${upper_devicename} Breath VOC Equivalent"
+     filters:
+      - median
     gas_resistance:
-      id: gas_resistance
-      name: "${upper_devicename} Gas Resistance"
+     id: gas_resistance
+     name: "${upper_devicename} Gas Resistance"
+     filters:
+     # Filter out sporadic power-up mega ohm values
+     - lambda: if (x > 1000000) { return {}; } return x;
+    co2_equivalent:
+      # CO2 equivalent estimate in ppm
+      id: co2
+      name: "${upper_devicename} CO2 Equivalent"
       filters:
-      # Filter out sporadic power-up mega ohm values
-      - lambda: if (x > 1000000) { return {}; } return x;
+        - median
+
+text_sensor:
+  - platform: bme680_bsec
+    iaq_accuracy:
+      name: "${upper_devicename} IAQ Accuracy"
+

--- a/esphome/sniffer_common.yaml
+++ b/esphome/sniffer_common.yaml
@@ -94,7 +94,7 @@ switch:
 time:
   - platform: homeassistant
     id: esptime
-    timezone: America/Los_Angeles
+    timezone: Australia/Sydney
 
 spi:
   clk_pin: GPIO18
@@ -130,21 +130,27 @@ display:
       it.printf(236, r, id(sz_24), color, TextAlign::TOP_RIGHT, "%0.0f AQI", id(pm_2_5_aqi).state);
 
       r += 21;
-      it.print(4,    r, id(sz_20), id(my_gray),   TextAlign::TOP_LEFT,  "PM:");
-      it.printf(236, r, id(sz_20), id(my_yellow), TextAlign::TOP_RIGHT, "%0.0f/%0.0f/%0.0f µg/m³", id(pm_1_0).state, id(pm_2_5).state, id(pm_10).state);
+      it.print(4,    r, id(sz_24), id(my_gray),   TextAlign::TOP_LEFT,  "VOC:");
+      
+      auto color_iaq = id(my_red);
+      if (id(iaq).state < 50) color_iaq = id(my_green);
+      else if (id(iaq).state < 100) color_iaq = id(my_yellow);
+      it.printf(236, r, id(sz_24), color_iaq, TextAlign::TOP_RIGHT, "%0.0f IAQ", id(iaq).state);
 
       r += 25;
       it.print(120,    r, id(sz_24), id(my_gray),   TextAlign::TOP_CENTER,  "Environment");
 
       r += 23;
       float temp_f = id(temp).state * (9.0/5.0) + 32.0;
-      it.printf(4,   r, id(sz_20), id(my_yellow), TextAlign::TOP_LEFT, "%0.1f°C", id(temp).state);
-      it.printf(125, r, id(sz_24), id(my_yellow), TextAlign::TOP_CENTER, "%0.1f°F", temp_f);
-      it.printf(236, r, id(sz_20), id(my_yellow), TextAlign::TOP_RIGHT,  "%0.1f%%", id(humidity).state);
+      it.printf(4,   r, id(sz_24), id(my_yellow), TextAlign::TOP_LEFT, "%0.1f°C", id(temp).state);
+      
+
+      
+      it.printf(236, r, id(sz_24), id(my_yellow), TextAlign::TOP_RIGHT,  "%0.1f%%", id(humidity).state);
 
       r += 21;
       it.printf(4,   r, id(sz_20), id(my_yellow), TextAlign::TOP_LEFT,  "%0.1f hPa", id(pressure).state);
-      it.printf(236, r, id(sz_20), id(my_yellow), TextAlign::TOP_RIGHT, "%0.1f kΩ",  id(gas_resistance).state/1000.0);
+      it.printf(236, r, id(sz_20), id(my_yellow), TextAlign::TOP_RIGHT, "co2 %0.0f ppm",  id(co2).state);
 
 
 

--- a/esphome/sniffer_common.yaml
+++ b/esphome/sniffer_common.yaml
@@ -143,9 +143,7 @@ display:
       r += 23;
       float temp_f = id(temp).state * (9.0/5.0) + 32.0;
       it.printf(4,   r, id(sz_24), id(my_yellow), TextAlign::TOP_LEFT, "%0.1f°C", id(temp).state);
-      
-
-      
+      it.printf(125, r, id(sz_24), id(my_yellow), TextAlign::TOP_CENTER, "%0.1f°F", temp_f);    
       it.printf(236, r, id(sz_24), id(my_yellow), TextAlign::TOP_RIGHT,  "%0.1f%%", id(humidity).state);
 
       r += 21;

--- a/kicad/lib/TTGO-T-DISPLAY.dcm
+++ b/kicad/lib/TTGO-T-DISPLAY.dcm
@@ -1,3 +1,9 @@
 EESchema-DOCLIB  Version 2.0
 #
+$CMP TTGO-T-Display
+D ESP32 Module with 1.14" Display and USB-C Connector
+K esp32
+F https://github.com/Xinyuan-LilyGO/TTGO-T-Display
+$ENDCMP
+#
 #End Doc Library

--- a/kicad/lib/TTGO-T-Display.dcm
+++ b/kicad/lib/TTGO-T-Display.dcm
@@ -1,3 +1,9 @@
 EESchema-DOCLIB  Version 2.0
 #
+$CMP TTGO-T-Display
+D ESP32 Module with 1.14" Display and USB-C Connector
+K esp32
+F https://github.com/Xinyuan-LilyGO/TTGO-T-Display
+$ENDCMP
+#
 #End Doc Library

--- a/kicad/lib/TTGO-T-Display.dcm
+++ b/kicad/lib/TTGO-T-Display.dcm
@@ -1,9 +1,3 @@
 EESchema-DOCLIB  Version 2.0
 #
-$CMP TTGO-T-Display
-D ESP32 Module with 1.14" Display and USB-C Connector
-K esp32
-F https://github.com/Xinyuan-LilyGO/TTGO-T-Display
-$ENDCMP
-#
 #End Doc Library


### PR DESCRIPTION
After doing some digging the Bosh BME680 has two ESPhome drivers, one is the base and the other is the full driver platform that has built in VOC functionality. This has been fully tested and display updated to reflect new Air quality values that are produced 